### PR TITLE
Fix "N instances should be drained but only M instances was drained"

### DIFF
--- a/internal/capacity/autoscalinggroup.go
+++ b/internal/capacity/autoscalinggroup.go
@@ -345,6 +345,8 @@ func (asg *AutoScalingGroup) waitUntilInstancesInService(ctx context.Context, ca
 			continue
 		case <-timer.C:
 			return xerrors.Errorf("can't prepare at least %d in-service instances within %v", capacity, timeout)
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/internal/capacity/autoscalinggroup.go
+++ b/internal/capacity/autoscalinggroup.go
@@ -39,7 +39,7 @@ func NewAutoScalingGroup(name string, asSvc AutoScalingAPI, ec2Svc EC2API) (*Aut
 	return &asg, nil
 }
 
-func (asg *AutoScalingGroup) ReplaceInstances(ctx context.Context, drainer Drainer) error {
+func (asg *AutoScalingGroup) ReplaceInstances(ctx context.Context, drainer Drainer, cluster Cluster) error {
 	oldInstanceIDs := make([]string, 0)
 	baseTime := asg.StateSavedAt
 	if baseTime == nil {
@@ -60,7 +60,13 @@ func (asg *AutoScalingGroup) ReplaceInstances(ctx context.Context, drainer Drain
 		return xerrors.Errorf("failed to launch new instances: %w", err)
 	}
 
-	if err := asg.terminateInstances(ctx, *asg.DesiredCapacity-*asg.OriginalDesiredCapacity, drainer); err != nil {
+	newInstanceCount := *asg.DesiredCapacity - *asg.OriginalDesiredCapacity
+	log.Printf("Wait for all the new instances to be registered in the cluster %q\n", cluster.Name())
+	if err := cluster.WaitUntilContainerInstancesRegistered(ctx, int(newInstanceCount), asg.StateSavedAt); err != nil {
+		return xerrors.Errorf("failed to wait until container instances are registered: %w", err)
+	}
+
+	if err := asg.terminateInstances(ctx, newInstanceCount, drainer); err != nil {
 		return xerrors.Errorf("failed to terminate instances: %w", err)
 	}
 

--- a/internal/capacity/autoscalinggroup_test.go
+++ b/internal/capacity/autoscalinggroup_test.go
@@ -425,6 +425,8 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 			asMock := capacitymock.NewMockAutoScalingAPI(ctrl)
 			ec2Mock := capacitymock.NewMockEC2API(ctrl)
 			drainerMock := capacitymock.NewMockDrainer(ctrl)
+			clusterMock := capacitymock.NewMockCluster(ctrl)
+			clusterMock.EXPECT().Name()
 
 			now := time.Now().UTC()
 			stateSavedAt := now.Format(time.RFC3339)
@@ -448,11 +450,13 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 					},
 				}, nil),
 
+				// For fetchInstances
 				ec2Mock.EXPECT().DescribeInstances(ctx, gomock.Any()).Return(&ec2.DescribeInstancesOutput{
 					Reservations: oldReservations,
 				}, nil),
 
 				expectLaunchNewInstances(t, ctx, asMock, tt.oldInstances, tt.newInstances, tt.desiredCapacity, tt.maxSize, stateSavedAt),
+				clusterMock.EXPECT().WaitUntilContainerInstancesRegistered(ctx, len(tt.newInstances), gomock.AssignableToTypeOf(&time.Time{})),
 				expectTerminateInstances(t, ctx, asMock, ec2Mock, drainerMock, tt.oldInstances, tt.newInstances, oldReservations, newReservations, tt.desiredCapacity, tt.maxSize),
 				expectRestoreState(t, ctx, asMock, tt.desiredCapacity, tt.maxSize, stateSavedAt),
 			)
@@ -462,7 +466,7 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := group.ReplaceInstances(ctx, drainerMock); err != nil {
+			if err := group.ReplaceInstances(ctx, drainerMock, clusterMock); err != nil {
 				t.Errorf("err = %#v; want nil", err)
 			}
 		})
@@ -480,6 +484,8 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 		asMock := capacitymock.NewMockAutoScalingAPI(ctrl)
 		ec2Mock := capacitymock.NewMockEC2API(ctrl)
 		drainerMock := capacitymock.NewMockDrainer(ctrl)
+		clusterMock := capacitymock.NewMockCluster(ctrl)
+		clusterMock.EXPECT().Name()
 
 		now := time.Now().UTC()
 		stateSavedAt := now.Format(time.RFC3339)
@@ -527,11 +533,13 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 				},
 			}, nil),
 
+			// For fetchInstances
 			ec2Mock.EXPECT().DescribeInstances(ctx, gomock.Any()).Return(&ec2.DescribeInstancesOutput{
 				Reservations: oldReservations,
 			}, nil),
 
 			expectLaunchNewInstances(t, ctx, asMock, oldInstances, newInstances, desiredCapacity, maxSize, stateSavedAt),
+			clusterMock.EXPECT().WaitUntilContainerInstancesRegistered(ctx, len(newInstances), gomock.AssignableToTypeOf(&time.Time{})),
 			expectTerminateInstances(t, ctx, asMock, ec2Mock, drainerMock, instancesToTerminate, instancesToKeep, reservationsToTerminate, reservationsToKeep, desiredCapacity, maxSize),
 			expectRestoreState(t, ctx, asMock, desiredCapacity, maxSize, stateSavedAt),
 		)
@@ -541,12 +549,12 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := group.ReplaceInstances(ctx, drainerMock); err != nil {
+		if err := group.ReplaceInstances(ctx, drainerMock, clusterMock); err != nil {
 			t.Errorf("err = %#v; want nil", err)
 		}
 	})
 
-	t.Run("replacement is already finished", func(t *testing.T) {
+	t.Run("replacement has already finished", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -558,6 +566,8 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 		asMock := capacitymock.NewMockAutoScalingAPI(ctrl)
 		ec2Mock := capacitymock.NewMockEC2API(ctrl)
 		drainerMock := capacitymock.NewMockDrainer(ctrl)
+		clusterMock := capacitymock.NewMockCluster(ctrl)
+		clusterMock.EXPECT().Name()
 
 		now := time.Now().UTC()
 		stateSavedAt := now.Format(time.RFC3339)
@@ -570,6 +580,7 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 		gomock.InOrder(
 			asMock.EXPECT().DescribeAutoScalingGroups(ctx, gomock.Any()).Return(&autoscaling.DescribeAutoScalingGroupsOutput{
 				AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
+					// NOTE: If replacement has already finished, DesiredCapacity is equal to OriginalDesiredCapacity
 					{
 						AutoScalingGroupName: aws.String("autoscaling-group-name"),
 						AvailabilityZones: []string{
@@ -584,10 +595,12 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 				},
 			}, nil),
 
+			// For fetchInstances
 			ec2Mock.EXPECT().DescribeInstances(ctx, gomock.Any()).Return(&ec2.DescribeInstancesOutput{
 				Reservations: createReservations(instances, now),
 			}, nil),
 
+			clusterMock.EXPECT().WaitUntilContainerInstancesRegistered(ctx, 0, gomock.AssignableToTypeOf(&time.Time{})),
 			expectRestoreState(t, ctx, asMock, desiredCapacity, maxSize, stateSavedAt),
 		)
 
@@ -596,7 +609,7 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := group.ReplaceInstances(ctx, drainerMock); err != nil {
+		if err := group.ReplaceInstances(ctx, drainerMock, clusterMock); err != nil {
 			t.Errorf("err = %#v; want nil", err)
 		}
 	})
@@ -614,6 +627,7 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 		ec2Mock := capacitymock.NewMockEC2API(ctrl)
 		drainerMock := capacitymock.NewMockDrainer(ctrl)
 		clusterMock := capacitymock.NewMockCluster(ctrl)
+		clusterMock.EXPECT().Name()
 
 		now := time.Now().UTC()
 		stateSavedAt := now.Format(time.RFC3339)
@@ -630,27 +644,34 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 		)
 		newReservations := createReservations(newInstances, now)
 
+		asg := autoscalingtypes.AutoScalingGroup{
+			AutoScalingGroupName: aws.String("autoscaling-group-name"),
+			AvailabilityZones: []string{
+				"ap-northeast-1a",
+				"ap-northeast-1c",
+			},
+			DesiredCapacity: aws.Int32(int32(len(oldInstances) + len(newInstances))),
+			Instances:       append(oldInstances, newInstances...),
+			MaxSize:         aws.Int32(int32(len(oldInstances) + len(newInstances))),
+			Tags:            createTagDescriptions(desiredCapacity, maxSize, stateSavedAt),
+		}
+
 		gomock.InOrder(
-			asMock.EXPECT().DescribeAutoScalingGroups(ctx, gomock.Any()).Times(2).Return(&autoscaling.DescribeAutoScalingGroupsOutput{
-				AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{
-					{
-						AutoScalingGroupName: aws.String("autoscaling-group-name"),
-						AvailabilityZones: []string{
-							"ap-northeast-1a",
-							"ap-northeast-1c",
-						},
-						DesiredCapacity: aws.Int32(int32(len(oldInstances) + len(newInstances))),
-						Instances:       append(oldInstances, newInstances...),
-						MaxSize:         aws.Int32(int32(len(oldInstances) + len(newInstances))),
-						Tags:            createTagDescriptions(desiredCapacity, maxSize, stateSavedAt),
-					},
-				},
+			asMock.EXPECT().DescribeAutoScalingGroups(ctx, gomock.Any()).Return(&autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{asg},
 			}, nil),
 
+			// For fetchInstances
 			ec2Mock.EXPECT().DescribeInstances(ctx, gomock.Any()).Return(&ec2.DescribeInstancesOutput{
-				Reservations: oldReservations,
+				Reservations: append(oldReservations, newReservations...),
 			}, nil),
 
+			// For launchNewInstances that calls waitUntilInstancesInService only once
+			asMock.EXPECT().DescribeAutoScalingGroups(ctx, gomock.Any()).Return(&autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: []autoscalingtypes.AutoScalingGroup{asg},
+			}, nil),
+
+			clusterMock.EXPECT().WaitUntilContainerInstancesRegistered(ctx, len(newInstances), gomock.AssignableToTypeOf(&time.Time{})),
 			expectTerminateInstances(t, ctx, asMock, ec2Mock, drainerMock, oldInstances, newInstances, oldReservations, newReservations, desiredCapacity, maxSize),
 			expectRestoreState(t, ctx, asMock, desiredCapacity, maxSize, stateSavedAt),
 		)
@@ -660,7 +681,7 @@ func TestAutoScalingGroup_ReplaceInstances(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := group.ReplaceInstances(ctx, drainerMock); err != nil {
+		if err := group.ReplaceInstances(ctx, drainerMock, clusterMock); err != nil {
 			t.Errorf("err = %#v; want nil", err)
 		}
 	})

--- a/internal/capacity/cluster.go
+++ b/internal/capacity/cluster.go
@@ -66,6 +66,8 @@ func (c *cluster) WaitUntilContainerInstancesRegistered(ctx context.Context, cou
 			continue
 		case <-timer.C:
 			return xerrors.Errorf("%d container instances expected to be registered but only %d instances were registered within %v", count, foundCount, timeout)
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }

--- a/internal/capacity/cluster.go
+++ b/internal/capacity/cluster.go
@@ -65,7 +65,7 @@ func (c *cluster) WaitUntilContainerInstancesRegistered(ctx context.Context, cou
 		case <-ticker.C:
 			continue
 		case <-timer.C:
-			return xerrors.Errorf("%d container instances expect to be registered but only %d instances were registered within %v", count, foundCount, timeout)
+			return xerrors.Errorf("%d container instances expected to be registered but only %d instances were registered within %v", count, foundCount, timeout)
 		}
 	}
 }

--- a/internal/capacity/cluster.go
+++ b/internal/capacity/cluster.go
@@ -1,0 +1,71 @@
+package capacity
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"golang.org/x/xerrors"
+)
+
+type Cluster interface {
+	Name() string
+	WaitUntilContainerInstancesRegistered(context.Context, int, *time.Time) error
+}
+
+type cluster struct {
+	name   string
+	ecsSvc ECSAPI
+}
+
+func NewCluster(name string, ecsSvc ECSAPI) Cluster {
+	return &cluster{
+		name:   name,
+		ecsSvc: ecsSvc,
+	}
+}
+
+func (c *cluster) Name() string {
+	return c.name
+}
+
+func (c *cluster) WaitUntilContainerInstancesRegistered(ctx context.Context, count int, registeredAt *time.Time) error {
+	if count == 0 {
+		return nil
+	}
+
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+
+	timeout := 5 * time.Minute
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	params := &ecs.ListContainerInstancesInput{
+		Cluster: aws.String(c.name),
+		Filter:  aws.String(fmt.Sprintf("registeredAt >= %s", registeredAt.UTC().Format(time.RFC3339))),
+	}
+	for {
+		foundCount := 0
+		paginator := ecs.NewListContainerInstancesPaginator(c.ecsSvc, params)
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				return xerrors.Errorf("failed to list container instances: %w", err)
+			}
+			foundCount += len(page.ContainerInstanceArns)
+		}
+		if foundCount == count {
+			return nil
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-timer.C:
+			return xerrors.Errorf("%d container instances expect to be registered but only %d instances were registered within %v", count, foundCount, timeout)
+		}
+	}
+}

--- a/internal/capacity/cluster_test.go
+++ b/internal/capacity/cluster_test.go
@@ -1,0 +1,36 @@
+package capacity
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/abicky/ecsmec/internal/testing/capacitymock"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	"go.uber.org/mock/gomock"
+)
+
+func TestCluster_WaitUntilContainerInstancesRegistered(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+
+	ecsMock := capacitymock.NewMockECSAPI(ctrl)
+
+	ecsMock.EXPECT().ListContainerInstances(ctx, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, params *ecs.ListContainerInstancesInput, _ ...func(options *ecs.Options)) (*ecs.ListContainerInstancesOutput, error) {
+			return &ecs.ListContainerInstancesOutput{
+				ContainerInstanceArns: []string{
+					fmt.Sprintf("arn:aws:ecs:ap-northeast-1:1234:container-instance/test/xxxxxxxxxx"),
+				},
+			}, nil
+		})
+
+	cluster := NewCluster("cluster", ecsMock)
+	now := time.Now()
+	if err := cluster.WaitUntilContainerInstancesRegistered(ctx, 1, &now); err != nil {
+		t.Errorf("err = %#v; want nil", err)
+	}
+}

--- a/internal/capacity/drainer.go
+++ b/internal/capacity/drainer.go
@@ -55,7 +55,7 @@ func (d *drainer) Drain(ctx context.Context, instanceIDs []string) error {
 		processedCount += len(instances)
 
 		arns := make([]*string, len(instances))
-		fmt.Printf("Drain the following container instances in the cluster \"%s\":\n", d.cluster)
+		fmt.Printf("Drain the following %d container instances in the cluster \"%s\":\n", len(instances), d.cluster)
 		for i, instance := range instances {
 			arns[i] = instance.ContainerInstanceArn
 			fmt.Printf("\t%s (%s)\n", getContainerInstanceID(*instance.ContainerInstanceArn), *instance.Ec2InstanceId)
@@ -72,7 +72,7 @@ func (d *drainer) Drain(ctx context.Context, instanceIDs []string) error {
 		return xerrors.Errorf("no target instances exist in the cluster \"%s\"", d.cluster)
 	}
 	if processedCount != len(instanceIDs) {
-		return xerrors.Errorf("%d instances should be drained but only %d instances was drained", len(instanceIDs), processedCount)
+		return xerrors.Errorf("%d instances should be drained but only %d instances were drained", len(instanceIDs), processedCount)
 	}
 
 	return nil
@@ -250,7 +250,7 @@ func (d *drainer) processContainerInstances(ctx context.Context, instanceIDs []s
 		}
 
 		if err := callback(resp.ContainerInstances); err != nil {
-			return xerrors.Errorf("failed to list container instances: %w", err)
+			return xerrors.Errorf("failed to execute the callback: %w", err)
 		}
 	}
 

--- a/internal/testing/capacitymock/generate.go
+++ b/internal/testing/capacitymock/generate.go
@@ -1,3 +1,3 @@
 package capacitymock
 
-//go:generate mockgen -package capacitymock -destination mocks.go github.com/abicky/ecsmec/internal/capacity AutoScalingAPI,Drainer,EC2API,ECSAPI,Poller,SQSAPI
+//go:generate mockgen -package capacitymock -destination mocks.go github.com/abicky/ecsmec/internal/capacity AutoScalingAPI,Drainer,EC2API,ECSAPI,Poller,SQSAPI,Cluster


### PR DESCRIPTION
This PR fixes the following error:

```
Error: failed to replace instances:
    github.com/abicky/ecsmec/cmd.newRuntimeError
        github.com/abicky/ecsmec/cmd/root.go:38
  - failed to terminate instances:
    github.com/abicky/ecsmec/internal/capacity.(*AutoScalingGroup).ReplaceInstances
        github.com/abicky/ecsmec/internal/capacity/autoscalinggroup.go:64
  - failed to drain instances:
    github.com/abicky/ecsmec/internal/capacity.(*AutoScalingGroup).terminateInstances
        github.com/abicky/ecsmec/internal/capacity/autoscalinggroup.go:212
  - 9 instances should be drained but only 8 instances was drained:
    github.com/abicky/ecsmec/internal/capacity.(*drainer).Drain
        github.com/abicky/ecsmec/internal/capacity/drainer.go:75
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to ensure container instances are registered before processing, improving reliability.
	- Enhanced logging to provide detailed information on the count of container instances being drained.
	- Added a new `Cluster` interface to manage cluster operations more effectively.

- **Bug Fixes**
	- Improved error messages for clarity when container registration fails.
	- Corrected grammatical inaccuracies in error messages related to processed instance counts.

- **Tests**
	- Added tests for the new `WaitUntilContainerInstancesRegistered` method to validate its functionality.
	- Updated test cases to incorporate the new cluster management functionality in instance replacement logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->